### PR TITLE
Require ServiceId, MessageContent in Create BatchMessages View

### DIFF
--- a/MessageSender/Models/BatchMessage.cs
+++ b/MessageSender/Models/BatchMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Web;
@@ -9,11 +10,12 @@ namespace MessageSender.Models
     public class BatchMessage : IValidatableObject
     {
         public int Id { get; set; }
-
+        
         [DataType(DataType.MultilineText)]
         public string MessageContent { get; set; }
-
+        
         public string ServiceId { get; set; }
+
         public string Sender { get; set; }
 
         [DisplayFormat(DataFormatString = "{0:yyyy-MM-ddTHH:mm}", ApplyFormatInEditMode = true)]

--- a/MessageSender/Views/BatchMessages/Create.cshtml
+++ b/MessageSender/Views/BatchMessages/Create.cshtml
@@ -38,7 +38,7 @@
                 <div class="form-group" data-bind="visible: selectedShortCode">
                     @Html.LabelFor(model => model.ServiceId, htmlAttributes: new { @class = "control-label col-md-2" })
                     <div class="col-md-10">
-                        <select name="ServiceId" id="ServiceId" data-bind="options: associatedServices, optionsCaption: 'Select Service...', optionsText: 'Name', optionsValue: 'ServiceId'" class="form-control"></select>
+                        <select name="ServiceId" id="ServiceId" data-bind="options: associatedServices, optionsCaption: 'Select Service...', optionsText: 'Name', optionsValue: 'ServiceId'" class="form-control" required></select>
                         @*@Html.DropDownListFor(model => model.ServiceId, (SelectList)ViewBag.Services, new { @class = "form-control" })*@
                         @Html.ValidationMessageFor(model => model.ServiceId, "", new { @class = "text-danger" })
                     </div>
@@ -56,7 +56,7 @@
                 <div class="form-group">
                     @Html.LabelFor(model => model.ServiceId, htmlAttributes: new { @class = "control-label col-md-2" })
                     <div class="col-md-10">
-                        @Html.EditorFor(model => model.ServiceId, new { htmlAttributes = new { @class = "form-control" } })
+                        @Html.EditorFor(model => model.ServiceId, new { htmlAttributes = new { @class = "form-control", minimum = "10", maximum = "20" } })
                         @Html.ValidationMessageFor(model => model.EndTime, "", new { @class = "text-danger" })
                     </div>
                 </div>
@@ -74,7 +74,7 @@
         <div class="form-group">
             @Html.LabelFor(model => model.MessageContent, htmlAttributes: new { @class = "control-label col-md-2" })
             <div class="col-md-10">
-                @Html.EditorFor(model => model.MessageContent, new { htmlAttributes = new { @class = "form-control", rows = "8" } })
+                @Html.EditorFor(model => model.MessageContent, new { htmlAttributes = new { @class = "form-control", rows = "8", required = "true" } })
                 @Html.ValidationMessageFor(model => model.MessageContent, "", new { @class = "text-danger" })
             </div>
         </div>


### PR DESCRIPTION
Tentative fix for issue #19 and #22.

This patch only makes sure that the form submitted by the user does not contain empty ServiceId and MessageContent.
The **database still allows nulls** for these fields.
It is proving tricky to create migrations that will run without having hardcoded SQL statements to update
the existing records with null values for these fields.
But this should suffice since it currently not apparent if there is a way for a user to bypass the HTML5 validation.