### PR TITLE
Fix Timestamp recording for mass message send request and response logs

### DIFF
--- a/MessageSender/Global.asax.cs
+++ b/MessageSender/Global.asax.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 using System.Web.Optimization;
 using System.Web.Routing;
 using System.Web.Http;
-using System.Web.Routing;
 
 namespace MessageSender
 {


### PR DESCRIPTION
Fix an issue that was leading to web requests and responses being not being logged immediately after being made.
This resulted in the timestamps being wildly inaccurate.